### PR TITLE
Preserve more unique information about tools etc at type-level by leveraging `satisfies`

### DIFF
--- a/packages/tools/src/BoltTool.ts
+++ b/packages/tools/src/BoltTool.ts
@@ -1,14 +1,7 @@
 import path from "path";
 import fs from "fs-extra";
 
-import {
-  Tool,
-  ToolType,
-  Package,
-  PackageJSON,
-  Packages,
-  InvalidMonorepoError,
-} from "./Tool";
+import { Tool, PackageJSON, Packages, InvalidMonorepoError } from "./Tool";
 import {
   expandPackageGlobs,
   expandPackageGlobsSync,
@@ -20,8 +13,8 @@ export interface BoltPackageJSON extends PackageJSON {
   };
 }
 
-export const BoltTool: Tool = {
-  type: "bolt",
+export const BoltTool = {
+  type: "bolt" as const,
 
   async isMonorepoRoot(directory: string): Promise<boolean> {
     try {
@@ -120,4 +113,4 @@ export const BoltTool: Tool = {
       );
     }
   },
-};
+} satisfies Tool;

--- a/packages/tools/src/LernaTool.ts
+++ b/packages/tools/src/LernaTool.ts
@@ -1,14 +1,7 @@
 import path from "path";
 import fs from "fs-extra";
 
-import {
-  Tool,
-  ToolType,
-  Package,
-  PackageJSON,
-  Packages,
-  InvalidMonorepoError,
-} from "./Tool";
+import { Tool, PackageJSON, Packages, InvalidMonorepoError } from "./Tool";
 import {
   expandPackageGlobs,
   expandPackageGlobsSync,
@@ -19,8 +12,8 @@ export interface LernaJson {
   packages?: string[];
 }
 
-export const LernaTool: Tool = {
-  type: "lerna",
+export const LernaTool = {
+  type: "lerna" as const,
 
   async isMonorepoRoot(directory: string): Promise<boolean> {
     try {
@@ -113,4 +106,4 @@ export const LernaTool: Tool = {
       );
     }
   },
-};
+} satisfies Tool;

--- a/packages/tools/src/PnpmTool.ts
+++ b/packages/tools/src/PnpmTool.ts
@@ -2,14 +2,7 @@ import path from "path";
 import readYamlFile, { sync as readYamlFileSync } from "read-yaml-file";
 import fs from "fs-extra";
 
-import {
-  Tool,
-  ToolType,
-  Package,
-  PackageJSON,
-  Packages,
-  InvalidMonorepoError,
-} from "./Tool";
+import { Tool, PackageJSON, Packages, InvalidMonorepoError } from "./Tool";
 import {
   expandPackageGlobs,
   expandPackageGlobsSync,
@@ -19,8 +12,8 @@ export interface PnpmWorkspaceYaml {
   packages?: string[];
 }
 
-export const PnpmTool: Tool = {
-  type: "pnpm",
+export const PnpmTool = {
+  type: "pnpm" as const,
 
   async isMonorepoRoot(directory: string): Promise<boolean> {
     try {
@@ -117,4 +110,4 @@ export const PnpmTool: Tool = {
       );
     }
   },
-};
+} satisfies Tool;

--- a/packages/tools/src/RushTool.ts
+++ b/packages/tools/src/RushTool.ts
@@ -4,7 +4,6 @@ import jju from "jju";
 
 import {
   Tool,
-  ToolType,
   Package,
   PackageJSON,
   Packages,
@@ -20,8 +19,8 @@ interface RushProject {
   projectFolder: string;
 }
 
-export const RushTool: Tool = {
-  type: "rush",
+export const RushTool = {
+  type: "rush" as const,
 
   async isMonorepoRoot(directory: string): Promise<boolean> {
     try {
@@ -129,4 +128,4 @@ export const RushTool: Tool = {
       );
     }
   },
-};
+} satisfies Tool;

--- a/packages/tools/src/SinglePackageTool.ts
+++ b/packages/tools/src/SinglePackageTool.ts
@@ -3,16 +3,14 @@ import fs from "fs-extra";
 
 import {
   Tool,
-  ToolType,
   Package,
   PackageJSON,
   Packages,
   InvalidMonorepoError,
 } from "./Tool";
-import { expandPackageGlobs } from "./expandPackageGlobs";
 
-export const SinglePackageTool: Tool = {
-  type: "singlePackage",
+export const SinglePackageTool = {
+  type: "singlePackage" as const,
 
   async isMonorepoRoot(directory: string): Promise<boolean> {
     // The single package tool is never the root of a monorepo.
@@ -79,4 +77,4 @@ export const SinglePackageTool: Tool = {
       );
     }
   },
-};
+} satisfies Tool;

--- a/packages/tools/src/Tool.ts
+++ b/packages/tools/src/Tool.ts
@@ -1,15 +1,4 @@
 /**
- * A unique string identifier for each type of supported monorepo tool.
- */
-export type ToolType =
-  | "bolt"
-  | "lerna"
-  | "pnpm"
-  | "rush"
-  | "singlePackage"
-  | "yarn";
-
-/**
  * A package.json access type.
  */
 export type PackageAccessType = "public" | "restricted";

--- a/packages/tools/src/YarnTool.ts
+++ b/packages/tools/src/YarnTool.ts
@@ -1,14 +1,7 @@
 import path from "path";
 import fs from "fs-extra";
 
-import {
-  Tool,
-  ToolType,
-  Package,
-  PackageJSON,
-  Packages,
-  InvalidMonorepoError,
-} from "./Tool";
+import { Tool, PackageJSON, Packages, InvalidMonorepoError } from "./Tool";
 import {
   expandPackageGlobs,
   expandPackageGlobsSync,
@@ -18,8 +11,8 @@ export interface YarnPackageJSON extends PackageJSON {
   workspaces?: string[] | { packages: string[] };
 }
 
-export const YarnTool: Tool = {
-  type: "yarn",
+export const YarnTool = {
+  type: "yarn" as const,
 
   async isMonorepoRoot(directory: string): Promise<boolean> {
     try {
@@ -122,4 +115,4 @@ export const YarnTool: Tool = {
       );
     }
   },
-};
+} satisfies Tool;

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -1,4 +1,4 @@
-import { Tool, ToolType } from "./Tool";
+import { Tool } from "./Tool";
 import { BoltTool } from "./BoltTool";
 import { LernaTool } from "./LernaTool";
 import { SinglePackageTool } from "./SinglePackageTool";
@@ -7,16 +7,27 @@ import { RushTool } from "./RushTool";
 import { YarnTool } from "./YarnTool";
 
 /**
+ * A unique string identifier for each type of supported monorepo tool.
+ */
+export type ToolType =
+  | typeof BoltTool["type"]
+  | typeof LernaTool["type"]
+  | typeof PnpmTool["type"]
+  | typeof RushTool["type"]
+  | typeof SinglePackageTool["type"]
+  | typeof YarnTool["type"];
+
+/**
  * A convenient mapping of tool type names to tool implementations.
  */
-const supportedTools: Record<ToolType, Tool> = {
+const supportedTools = {
   bolt: BoltTool,
   lerna: LernaTool,
   pnpm: PnpmTool,
   rush: RushTool,
   singlePackage: SinglePackageTool,
   yarn: YarnTool,
-};
+} satisfies Record<ToolType, Tool>;
 
 /**
  * A default ordering for monorepo tool checks.
@@ -25,14 +36,14 @@ const supportedTools: Record<ToolType, Tool> = {
  * monorepo implementations first, with tools based on custom file scchemas
  * checked last.
  */
-const defaultOrder: ToolType[] = [
+const defaultOrder = [
   "yarn",
   "bolt",
   "pnpm",
   "lerna",
   "rush",
   "singlePackage",
-];
+] as const satisfies readonly [...ToolType[]];
 
 export * from "./Tool";
 export {


### PR DESCRIPTION
This is up for debate. It's quite cool that we can preserve more information on each of those adjusted runtime values - for example, `typeof LernaTool['type']` is always `'lerna'` and not `ToolType`.

We could implement some further tricks to improve the readability since now those specific Tool types become "anonymous" and are printed like this:
<img width="551" alt="verbose type information printed for the supportedTools variable" src="https://user-images.githubusercontent.com/9800850/209945969-aa2967bd-c2d2-4237-81c7-a5080e79726c.png">

